### PR TITLE
Bug fix 914

### DIFF
--- a/CleanupUtility/PickupChecker.cs
+++ b/CleanupUtility/PickupChecker.cs
@@ -10,6 +10,7 @@ namespace CleanupUtility
     using Exiled.API.Enums;
     using Exiled.API.Features;
     using Exiled.API.Features.Items;
+    using InventorySystem.Items.Usables.Scp330;
     using MEC;
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
HotFix: Seems 914 logic spams just fast enough where objects can be in mid-destruction and cause issues. Protecting the transpiler code from breaking that.