### PR TITLE
Pocket dimension cleanup based on item, time limit, etc.

### DIFF
--- a/CleanupUtility/Config.cs
+++ b/CleanupUtility/Config.cs
@@ -27,12 +27,20 @@ namespace CleanupUtility
         /// <summary>
         /// Gets or sets a value indicating whether items should be cleaned up.
         /// </summary>
-        public bool CleanupItems { get; internal set; }
+        [Description("Gets or sets a value indicating whether items should be cleaned up.")]
+        public bool CleanupItems { get; set; } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether ragdolls should be cleaned up.
         /// </summary>
-        public bool CleanupRagDolls { get; internal set; }
+        [Description("Gets or sets a value indicating whether ragdolls should be cleaned up.")]
+        public bool CleanupRagDolls { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets value indicating whether to clean in pocket dimension.
+        /// </summary>
+        [Description("Gets or sets a value indicating whether to clean in pocket dimension.")]
+        public bool CleanInPocket { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the time, in seconds, between each check of the list of items to delete.
@@ -156,7 +164,7 @@ namespace CleanupUtility
         /// Gets or sets existence time limit for ragdolls.
         /// </summary>
         [Description("Time limit for ragdoll existence.")]
-        public float RagdollExistenceLimit { get; set; }
+        public float RagdollExistenceLimit { get; set; } = 10;
 
         /// <summary>
         /// Gets or sets a acceptable cleanup Zones.

--- a/CleanupUtility/Config.cs
+++ b/CleanupUtility/Config.cs
@@ -111,7 +111,7 @@ namespace CleanupUtility
         /// Gets or sets a collection of ItemTypes that should be deleted by Zone.
         /// </summary>
         [Description("Filter on what zone item type can be cleared from.")]
-        public Dictionary<ItemType, HashSet<ZoneType>> ZoneFilter { get; set; } = new ()
+        public Dictionary<ItemType, HashSet<ZoneType>> ZoneFilter { get; set; } = new()
         {
             { ItemType.KeycardJanitor, new HashSet<ZoneType>() { ZoneType.Unspecified } },
             { ItemType.KeycardScientist, new HashSet<ZoneType>() { ZoneType.Unspecified } },

--- a/CleanupUtility/Patches/ServerCreatePickupPatch.cs
+++ b/CleanupUtility/Patches/ServerCreatePickupPatch.cs
@@ -5,8 +5,6 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-#pragma warning disable SA1118
-
 namespace CleanupUtility.Patches
 {
     using System;
@@ -130,7 +128,7 @@ namespace CleanupUtility.Patches
                 new CodeInstruction(OpCodes.Ldloc_0),
 
                 // Calls pickup method using local variable 0 (Which is on Eval Stack [ItemPickupBase]) and it gets back a Pickup object onto the EStack [Pickup]
-                new CodeInstruction(OpCodes.Call, Method(typeof(Pickup), nameof(Pickup.Get), new[] {typeof(ItemPickupBase)})),
+                new CodeInstruction(OpCodes.Call, Method(typeof(Pickup), nameof(Pickup.Get), new[] { typeof(ItemPickupBase) })),
 
                 // Calls arguemnt 1 from function call unto EStack (Zone)
                 new CodeInstruction(OpCodes.Ldloc, itemZone.LocalIndex),

--- a/CleanupUtility/Plugin.cs
+++ b/CleanupUtility/Plugin.cs
@@ -55,15 +55,11 @@ namespace CleanupUtility
             ServerEvents.RestartingRound += this.PickupChecker.OnRestartingRound;
             if (this.Config.CleanInPocket)
             {
-                if (this.Config.CleanupItems)
-                {
-                    PlayerEvents.EnteringPocketDimension += this.PickupChecker.OnPocketEnter;
-                }
-
-                if (this.Config.CleanupRagDolls)
-                {
-                    PlayerEvents.EscapingPocketDimension += this.PickupChecker.OnPocketExit;
-                }
+                PlayerEvents.EnteringPocketDimension += this.PickupChecker.OnPocketEnter;
+                PlayerEvents.EscapingPocketDimension += this.PickupChecker.OnPocketExit;
+                // On Died might be overkill but OnRoleChange is much more guaranteed.
+                PlayerEvents.Died += this.PickupChecker.OnDied;
+                PlayerEvents.ChangingRole += this.PickupChecker.OnRoleChange;
             }
 
             base.OnEnabled();
@@ -77,15 +73,10 @@ namespace CleanupUtility
 
             if (this.Config.CleanInPocket)
             {
-                if (this.Config.CleanupItems)
-                {
-                    PlayerEvents.EnteringPocketDimension -= this.PickupChecker.OnPocketEnter;
-                }
-
-                if (this.Config.CleanupRagDolls)
-                {
-                    PlayerEvents.EscapingPocketDimension -= this.PickupChecker.OnPocketExit;
-                }
+                PlayerEvents.EnteringPocketDimension -= this.PickupChecker.OnPocketEnter;
+                PlayerEvents.EscapingPocketDimension -= this.PickupChecker.OnPocketExit;
+                PlayerEvents.Died -= this.PickupChecker.OnDied;
+                PlayerEvents.ChangingRole -= this.PickupChecker.OnRoleChange;
             }
 
             this.PickupChecker = null;

--- a/CleanupUtility/Plugin.cs
+++ b/CleanupUtility/Plugin.cs
@@ -10,6 +10,7 @@ namespace CleanupUtility
     using System;
     using Exiled.API.Features;
     using HarmonyLib;
+    using PlayerEvents = Exiled.Events.Handlers.Player;
     using ServerEvents = Exiled.Events.Handlers.Server;
 
     /// <summary>
@@ -34,7 +35,7 @@ namespace CleanupUtility
         public override Version RequiredExiledVersion { get; } = new(5, 3, 0);
 
         /// <inheritdoc />
-        public override Version Version { get; } = new(1, 2, 2);
+        public override Version Version { get; } = new(1, 2, 3);
 
         /// <summary>
         /// Gets an instance of the <see cref="PickupChecker"/> class.
@@ -52,6 +53,18 @@ namespace CleanupUtility
             this.PickupChecker = new PickupChecker(this);
             ServerEvents.RoundStarted += this.PickupChecker.OnRoundStarted;
             ServerEvents.RestartingRound += this.PickupChecker.OnRestartingRound;
+            if (this.Config.CleanInPocket)
+            {
+                if (this.Config.CleanupItems)
+                {
+                    PlayerEvents.EnteringPocketDimension += this.PickupChecker.OnPocketEnter;
+                }
+
+                if (this.Config.CleanupRagDolls)
+                {
+                    PlayerEvents.EscapingPocketDimension += this.PickupChecker.OnPocketExit;
+                }
+            }
 
             base.OnEnabled();
         }
@@ -61,6 +74,19 @@ namespace CleanupUtility
         {
             ServerEvents.RoundStarted -= this.PickupChecker.OnRoundStarted;
             ServerEvents.RestartingRound -= this.PickupChecker.OnRestartingRound;
+
+            if (this.Config.CleanInPocket)
+            {
+                if (this.Config.CleanupItems)
+                {
+                    PlayerEvents.EnteringPocketDimension -= this.PickupChecker.OnPocketEnter;
+                }
+
+                if (this.Config.CleanupRagDolls)
+                {
+                    PlayerEvents.EscapingPocketDimension -= this.PickupChecker.OnPocketExit;
+                }
+            }
 
             this.PickupChecker = null;
 


### PR DESCRIPTION
Sets rules up to cleanup player items in pocket dimension. Additionally, allows dynamic only rag-doll/only item cleanup.